### PR TITLE
introactivity: allow to override onCreate again

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Watch it on [YouTube](https://www.youtube.com/watch?v=4vUe8xVAEIM).
 ## How do I use IntroActivity?
 Simple. Just create an `Activity` and extend `IntroActivity.`
 
-By extending `IntroActivity`, you'll automatically implement the `initialize()` method. This is where you set up your intro screens and any custom styling. It is not possible to override `onCreate()` as this is used by the library to set up your intro screen.
+By extending `IntroActivity`, you'll automatically implement the `initialize()` method. This is where you set up your intro screens and any custom styling.
+If you need to override `onCreate()`, be sure to call `super.onCreate()`, as the library relies on it.
 
 Here's an example of how to extend `IntroActivity` and add a basic intro screen:
 

--- a/library/src/main/java/com/miz/introactivity/IntroActivity.java
+++ b/library/src/main/java/com/miz/introactivity/IntroActivity.java
@@ -3,6 +3,7 @@ package com.miz.introactivity;
 import android.animation.ArgbEvaluator;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
@@ -28,7 +29,8 @@ public abstract class IntroActivity extends AppCompatActivity {
     private int mProgressCircleColor;
 
     @Override
-    protected final void onCreate(Bundle savedInstanceState) {
+    @CallSuper
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         setTheme(R.style.IntroActivity_Theme);


### PR DESCRIPTION
- remove final from onCreate to allow overriding
- as the library depends on calling onCreate, add a CallSuper annotation
  to tell the library user that super.onCreate has to be called

Change-Id: Iee55651b080c05c6d655666a3c449d4ea5691b51
Signed-off-by: Alexander Martinz eviscerationls@gmail.com
